### PR TITLE
Remove reading of unused byte

### DIFF
--- a/word2vec.go
+++ b/word2vec.go
@@ -52,11 +52,6 @@ func FromReader(r io.Reader) (*Model, error) {
 
 		v.Normalise()
 
-		_, err = br.ReadByte()
-		if err != nil {
-			return nil, err
-		}
-
 		m.words[w] = v
 	}
 	return m, nil


### PR DESCRIPTION
In my tests the first byte of each word is being stripped, remove this read should fix the issue.