### PR TITLE
Add option to lazy load the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,59 @@ matches, err := model.CosN(expr, 1)
 if err != nil {
 	log.Fatalf("error evaluating cosine similarity: %v", err)
 }
+
+// Create two expressions.
+x := word2vec.Expr{"king": 1.0}
+y := word2vec.Expr{"queen": 1.0}
+
+// Compute similarity between the expressions
+cosineSimilarity, err := m.Cos(x, y)
+if err != nil {
+    log.Fatalf("error evaluating cosine similarity: %v", err)
+}
+
+```
+
+If you only wanna to compute similarity between some words, but not to find the n most similar of a given word,
+you can use a lazy model, which initializes faster and uses less memory:
+
+```go
+// Lazy load the model from an io.Reader (i.e. a file).
+model, err := word2vec.LazyFromReader(r)
+if err != nil {
+	log.Fatalf("error loading model: %v", err)
+}
+
+// Create two expressions.
+x := word2vec.Expr{"king": 1.0}
+y := word2vec.Expr{"queen": 1.0}
+
+// Compute similarity between the expressions
+cosineSimilarity, err := m.Cos(x, y)
+if err != nil {
+    log.Fatalf("error evaluating cosine similarity: %v", err)
+}
+
+```
+
+Below is a benchmark between the normal and the lazy model using a model file with 456.976 (26 ^ 4) words of 300 dimensions.
+You can run the benchmark with your model declaring the var ```filename``` of ```word2vec_bench_test.go``` to the path of your binary model.
+
+
+```
+BenchmarkLazyModel
+BenchmarkLazyModel/InitializeEager
+BenchmarkLazyModel/InitializeEager-4         	       1	4217573971 ns/op	1193506272 B/op	 1370948 allocs/op
+BenchmarkLazyModel/InitializeLazy
+BenchmarkLazyModel/InitializeLazy-4            	       4	 321390344 ns/op	  31409760 B/op	  456996 allocs/op
+BenchmarkLazyModel/LoadVectorEager
+BenchmarkLazyModel/LoadVectorEager-4                  4769024	       266.2 ns/op	     400 B/op	       2 allocs/op
+BenchmarkLazyModel/LoadVectorLazy
+BenchmarkLazyModel/LoadVectorLazy-4                    151197	        8163 ns/op	    3032 B/op	       6 allocs/op
+
+4217573971ns = 4,21s
+321390344ns  = 0,32s
+1193506272B  = 1,19GB
+31409760B    = 0,03GB(31MB)
+
 ```

--- a/offset_counter.go
+++ b/offset_counter.go
@@ -1,0 +1,60 @@
+package word2vec
+
+import "bufio"
+
+type offsetCounter struct {
+	offset int64
+	reader *bufio.Reader
+}
+
+func (o *offsetCounter) Discard(n int) (discarded int, err error) {
+	discarded, err = o.reader.Discard(n)
+	o.offset += int64(discarded)
+	return
+}
+
+func (o *offsetCounter) ReadByte() (byte, error) {
+	b, err := o.reader.ReadByte()
+	if err == nil {
+		o.offset++
+	}
+	return b, err
+}
+
+func (o *offsetCounter) ReadRune() (r rune, size int, err error) {
+	r, size, err = o.reader.ReadRune()
+	o.offset += int64(size)
+	return
+}
+
+func (o *offsetCounter) ReadSlice(delim byte) (line []byte, err error) {
+	line, err = o.reader.ReadSlice(delim)
+	o.offset += int64(len(line))
+	return
+}
+
+func (o *offsetCounter) ReadBytes(delim byte) ([]byte, error) {
+	b, err := o.reader.ReadBytes(delim)
+	o.offset += int64(len(b))
+	return b, err
+}
+
+func (o *offsetCounter) ReadString(delim byte) (string, error) {
+	s, err := o.reader.ReadString(delim)
+	o.offset += int64(len(s))
+	return s, err
+}
+
+func (o *offsetCounter) Read(p []byte) (n int, err error) {
+	n, err = o.reader.Read(p)
+	o.offset += int64(n)
+	return
+}
+
+func (o *offsetCounter) UnreadByte() error {
+	err := o.reader.UnreadByte()
+	if err == nil {
+		o.offset--
+	}
+	return err
+}

--- a/word2vec_bench_test.go
+++ b/word2vec_bench_test.go
@@ -1,0 +1,143 @@
+package word2vec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var filename = "" //set this to the path of your model file to a more precise bench
+
+func BenchmarkLazyModel(b *testing.B) {
+
+	var (
+		f   *os.File
+		err error
+	)
+
+	if filename == "" {
+		f, err = os.Create(filepath.Join(b.TempDir(), "go-word2vec-bench.bin"))
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer f.Close()
+
+		dim := 300
+		numWords := 26 * 26 * 26 * 26
+
+		buf := bytes.NewBuffer(make([]byte, 0, 500_000))
+
+		_, err := fmt.Fprintln(buf, numWords, dim)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		emptyVector := make([]float32, dim)
+
+		for i := 'a'; i <= 'z'; i++ {
+			for j := 'a'; j <= 'z'; j++ {
+				for k := 'a'; k <= 'z'; k++ {
+					for l := 'a'; l <= 'z'; l++ {
+						_, err := fmt.Fprintf(buf, "%s%s%s%s ", string(i), string(j), string(k), string(l))
+						if err != nil {
+							b.Fatal("unexpected error writing word")
+						}
+						err = binary.Write(buf, binary.LittleEndian, emptyVector)
+						if err != nil {
+							b.Fatal("unexpected error writing vector")
+						}
+						_, err = fmt.Fprintf(buf, "\n")
+						if err != nil {
+							b.Fatal("unexpected error writing new line")
+						}
+					}
+				}
+			}
+		}
+		bb := buf.Bytes()
+
+		_, err = f.Write(bb)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		_, err = f.Seek(0, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+	} else {
+		f, err = os.Open(filename)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer f.Close()
+	}
+
+	b.Run("InitializeEager", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := FromReader(f)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_, err = f.Seek(0, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("InitializeLazy", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := LazyFromReader(f)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_, err = f.Seek(0, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	m, err := FromReader(f)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("LoadVectorEager", func(b *testing.B) {
+
+		for i := 0; i < b.N; i++ {
+			r := m.Map([]string{"abcd"})
+			if len(r) == 0 {
+				b.Fatal("empty return")
+			}
+		}
+
+	})
+
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	l, err := LazyFromReader(f)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("LoadVectorLazy", func(b *testing.B) {
+
+		for i := 0; i < b.N; i++ {
+			r := l.Map([]string{"abcd"})
+			if len(r) == 0 {
+				b.Fatal("empty return")
+			}
+		}
+
+	})
+
+}


### PR DESCRIPTION
Add method to lazy load the model, saving only
the offset at each word vector starts on the 
io.Reader, and reading at it only when needed
Adds a flag lazy on word-server to use it
Also calls file.Close() on word-server in
case of error loading the model, because the
deferred one isn't called after os.Exit

